### PR TITLE
Patch largo avatar issue

### DIFF
--- a/wp-content/themes/sfpublicpress/functions.php
+++ b/wp-content/themes/sfpublicpress/functions.php
@@ -78,8 +78,10 @@ function sfpp_largo_custom_avatar( $avatar, $id_or_email, $args ) {
 
     if ( $user && is_object( $user ) ) {
 
-		if( function_exists( 'largo_get_user_avatar_id' ) ) {
-			$avatar = wp_get_attachment_image( largo_get_user_avatar_id( $user->ID ), 96, false, array( 'alt' => $user->display_name ) );
+		if( function_exists( 'largo_has_avatar' ) && function_exists( 'largo_get_user_avatar_id' ) ) {
+			if( largo_has_avatar( $user->user_email ) ) {
+				$avatar = wp_get_attachment_image( largo_get_user_avatar_id( $user->ID ), 96, false, array( 'alt' => $user->display_name ) );
+			}
 		}
 
     }


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Filters [pre_get_avatar](https://developer.wordpress.org/reference/hooks/pre_get_avatar/) so that we can make `get_avatar()` use the largo_avatar value if it exists

Related: https://github.com/INN/largo/issues/1864

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/INN/largo/issues/1864

## Testing/Questions

Features that this PR affects:

- Avatars and user images

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Add an image to a user in the `largo_avatar` field and make sure it displays on the authors archive page