### PR TITLE
make options box use correct class name again, and fix more undefined variables

### DIFF
--- a/wp-content/themes/sfpublicpress/inc/widgets/sfpublicpress-promo-box.php
+++ b/wp-content/themes/sfpublicpress/inc/widgets/sfpublicpress-promo-box.php
@@ -33,7 +33,7 @@ class sfpublicpress_promo_box_widget extends WP_Widget {
 	 */
 	function __construct() {
 		$widget_ops = array(
-			'classname' => 'sfpublicpress-promo-box',
+			'classname' => 'widget_sfpublicpress-promo-box',
 			'description'=> __('Widget to display promo boxes.', 'sfpublicpress')
 		);
 
@@ -224,7 +224,7 @@ class sfpublicpress_promo_box_widget extends WP_Widget {
 				'class' => 	$this->widget_options['classname'].'-image-link',
 				'title' => ( !empty( $instance['alt'] ) ) ? $instance['alt'] : $instance['title'],
 			);
-			if ( isset( $instance['track'] ) ) $attr['class'] .= ' image-click-track';
+			if ( isset( $instance['track'] ) && $instance['track'] ) $attr['class'] .= ' image-click-track';
 			$attr = apply_filters('image_widget_link_attributes', $attr, $instance );
 			$attr = array_map( 'esc_attr', $attr );
 			$output = '<a';


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- defines the instance height and width variables
- sets the classname to the value it had pre-#87 when it was automatically generated

Before:
![Screen Shot 2020-06-11 at 17 51 10](https://user-images.githubusercontent.com/1754187/84442851-6e663b00-ac0c-11ea-93a4-96c74aece3b9.png)

After:
![Screen Shot 2020-06-11 at 17 50 41](https://user-images.githubusercontent.com/1754187/84442849-6c9c7780-ac0c-11ea-9de6-6e7a94b1ce1e.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Because I broke this with a fix for undefined variables in #87

## Testing/Questions

Features that this PR affects:

- optional promo box on homepage

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] looks right?

Steps to test this PR:

1. view homepage