### PR TITLE
pre_get_posts filter to remove cats_home categories from homepage

### DIFF
--- a/wp-content/themes/sfpublicpress/homepages/layout.php
+++ b/wp-content/themes/sfpublicpress/homepages/layout.php
@@ -54,7 +54,6 @@ class SFPublicPress extends Homepage {
 
 			if ( ! empty( $exclude ) ) {
 				$query->set( 'category__not_in', $exclude );
-				error_log(var_export( $query->query_vars, true));
 			}
 		}
 


### PR DESCRIPTION
For https://github.com/INN/umbrella-sfpublicpress/issues/104

## Changes

This pull request makes the following changes:

- Adds a filter that 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #104

## Testing/Questions

Features that this PR affects:

- all WP_Query calls

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] does this run on any places that are not the homepage?

Steps to test this PR:

0. Find the term ID of the "From the Newsroom" category. If you've got a DB dump more recent than Monday, it's `3952`. In Dashboard > Appearance > Theme Options > Layout > Other Homepage Display Options, put that ID in the "Categories to include or exclude" box, and save the theme options
1. tail your debug log. This is the mechanism by which you can check whether this is running on non-homepage requests.
2. Visit the homepage:
    - there should be a lot of log noise.
3. Visit the admin:
    - there should be no log noise
4. Visit term archives, author pages, category archives:
   - there should be no log noise

Once this has been verified to work on a computer other than mine, I'll remove the `error_log` generating all the noise, and deploy this to staging.