### PR TITLE
Use featured post ID that's already available

### DIFF
--- a/wp-content/themes/sfpublicpress/partials/archive-category-primary-feature.php
+++ b/wp-content/themes/sfpublicpress/partials/archive-category-primary-feature.php
@@ -16,9 +16,9 @@
 			</h2>
 
 			<div class="byline">
-                    <div class="byline-date"><?php echo get_the_date( 'm.d.Y', get_the_ID() ); ?></div>
+                    <div class="byline-date"><?php echo get_the_date( 'm.d.Y', $featured_post->ID ); ?></div>
                     <span class="sep"> | </span>
-                    <h5 class="byline"><?php largo_byline( true, true, get_the_ID() ); ?></h5>
+					<h5 class="byline"><?php largo_byline( true, true, $featured_post->ID ); ?></h5>
             </div>
 		</header>
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates the primary featured archive partial to use `$featured_post->ID` instead of `get_the_ID()` when calling `largo_byline()` because I made an oopsie

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #116 

## Testing/Questions

Features that this PR affects:

- Featured post on archives

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. View an archive that has featured/secondary/all posts and make sure the top featured post has the correct byline