### PR TITLE
Explicitly specify the ID of the post with the top term.

### DIFF
--- a/wp-content/themes/sfpublicpress/partials/content.php
+++ b/wp-content/themes/sfpublicpress/partials/content.php
@@ -58,7 +58,7 @@ if ( $featured ) {
 		echo '<div class="' . $entry_classes . '">';
 
 		if ( largo_has_categories_or_tags() ) {
-			largo_maybe_top_term();
+			largo_maybe_top_term( array( 'post' => get_the_ID() ) );
 		}
 
 		if ( $show_thumbnail ) {

--- a/wp-content/themes/sfpublicpress/partials/home-top.php
+++ b/wp-content/themes/sfpublicpress/partials/home-top.php
@@ -9,7 +9,7 @@
 	<div class="post-image-top-term-container">
         <?php
             // The top term
-            largo_maybe_top_term();
+            largo_maybe_top_term( array( 'post' => $topstory->ID ) );
         ?>
 		<a class="img" href="<?php echo esc_attr( get_permalink( $topstory ) ); ?>"><?php echo get_the_post_thumbnail( $topstory, 'large' ); ?></a>
     </div>

--- a/wp-content/themes/sfpublicpress/partials/widget-content.php
+++ b/wp-content/themes/sfpublicpress/partials/widget-content.php
@@ -20,7 +20,7 @@ if ( $podcast === true ) {
             <?php
                 // The top term
                 if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() ) {
-                    largo_maybe_top_term();
+                    largo_maybe_top_term( array( 'post' => get_the_ID() ) );
                 }
             ?>
             <a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), '60x60', $img_attr); ?></a>
@@ -35,7 +35,7 @@ if ( $podcast === true ) {
             <?php
                 // The top term
                 if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() ) {
-                    largo_maybe_top_term();
+                    largo_maybe_top_term( array( 'post' => get_the_ID() ) );
                 }
             ?>
             <a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'post-thumbnail', $img_attr); ?></a>
@@ -49,7 +49,7 @@ if ( $podcast === true ) {
             <?php
                 // The top term
                 if ( isset( $instance['show_top_term'] ) && $instance['show_top_term'] == 1 && largo_has_categories_or_tags() ) {
-                    largo_maybe_top_term();
+                    largo_maybe_top_term( array( 'post' => get_the_ID() ) );
                 }
             ?>
             <a href="<?php echo get_permalink(); ?>"><?php echo get_the_post_thumbnail( get_the_ID(), 'two-third-full', $img_attr); ?></a>


### PR DESCRIPTION


## Changes

This pull request makes the following changes:

- This will hopefully 🤞 make the top term on the homepage top story match what is set in that post's settings. The reason we need to do this is because this post is not in The Loop. 
- also does it in widget content and generic content partials for safety. 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Fixes https://github.com/INN/umbrella-sfpublicpress/issues/115

## Testing/Questions

Features that this PR affects:

- homepage, widget content

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Change the top term on the homepage top story, and make sure that it's reflected in this PR. 
