### PR TITLE
add excerpt box allowing page excerpts to be set.

### DIFF
--- a/wp-content/themes/sfpublicpress/functions.php
+++ b/wp-content/themes/sfpublicpress/functions.php
@@ -108,4 +108,13 @@ function largo_donate_button () {
 		);
 	}
 }
-	
+
+/**
+ * Add support for post excerpts to the 'page' post type
+ *
+ * @link https://www.wp-code.com/wordpress-snippets/add-excerpts-to-wordpress-pages/
+ * @link https://github.com/INN/umbrella-sfpublicpress/issues/121
+ */
+add_action( 'init', function() {
+	add_post_type_support( 'page', 'excerpt' );
+});


### PR DESCRIPTION
Fixes https://github.com/INN/umbrella-sfpublicpress/issues/121

## Changes

This pull request makes the following changes:

- Adds the excerpt editing box to the 'page' post type. 

![Screen Shot 2020-06-26 at 19 35 38](https://user-images.githubusercontent.com/1754187/85908742-5c77c100-b7e4-11ea-831a-4bb45a9b5b70.png)

This allows page excerpts to be changed, so that pages no longer have the whole post content in the post_excerpt field, which was the root cause of https://github.com/INN/umbrella-sfpublicpress/issues/121

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/INN/umbrella-sfpublicpress/issues/121

## Testing/Questions

Features that this PR affects:

- editor on pages

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [x] Will SFPP have to edit all these pages?
    - Yes.

Steps to test this PR:

1. Find a page with a very long excerpt in search, such as any in http://sfpublicpress.flywheelsites.com/?s=seth+rosenfeld&search+submit=
2. Edit the post, change the excerpt.
3. The updated excerpt should now be visible on the search-results page.

Note that if the excerpt contained the search query, because excerpts containing the search query are prioritized above post content containing the search query, the queried item's position in the search may change if the edited excerpt does not have the search terms.