### PR TITLE
Overwrite largo_gallery_enqueue function

### DIFF
--- a/wp-content/themes/sfpublicpress/functions.php
+++ b/wp-content/themes/sfpublicpress/functions.php
@@ -120,6 +120,7 @@ add_action( 'init', function() {
  * navis slideshow/lightbox CSS or JS is loaded into the theme
  * 
  * @see https://github.com/INN/largo/blob/590181982d22a5444eb3c5ccca58ea8b56db12f7/inc/enqueue.php#L80-L122
+ * @see https://github.com/INN/umbrella-sfpublicpress/issues/139
  * 
  * Will eventually be added back once a design is approved by SFPP
  */


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Overwrites the `largo_gallery_enqueue` function from https://github.com/INN/largo/blob/590181982d22a5444eb3c5ccca58ea8b56db12f7/inc/enqueue.php#L80-L122 so that it doesn't actually enqueue anything

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #139

## Testing/Questions

Features that this PR affects:

- Anything using navis slideshows/lightboxes

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Is there an easier way to temporarily disable this?

Steps to test this PR:

1. Make sure nothing is broken
2. Go to a post with images and make sure none open a lightbox if clicked