### PR TITLE
Rough draft at attempting automated redirects for terms

### DIFF
--- a/wp-content/themes/sfpublicpress/functions.php
+++ b/wp-content/themes/sfpublicpress/functions.php
@@ -182,7 +182,7 @@ function sfpp_category_tag_404_override() {
 				include_once WP_PLUGIN_DIR . '/redirection/models/group.php';
 
 				// let's make sure the user doesn't actually experience a 404
-				status_header( 301 );
+				status_header( 303 );
 				$wp_query->is_404=false;
 
 				// set up all of our relevant info we need to creat the redirect in the plugin


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Creates a new function `sfpp_category_tag_404_override` that hooks into the `template_redirect` filter and attempts to automate creation of a redirect for category and tag terms to `/categories/`  if the url ends up being a 404

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #97

## Testing/Questions

Features that this PR affects:

- Categories and tag urls that 404

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] What edge cases did I forget?
- [ ] What security issues does this present?
- [ ] Anything we need to change in the `$redirection_info` array?
- [x] Could anything in it be more modular? ie: should `/categories/` be hardcoded or should we instead grab a specific post id and grab its permalink?

Steps to test this PR:

1. Attempt to go to a category/tag url that will 404, such as https://sfpp.test/category/howdyhowdyhowdy or https://sfpp.test/tag/goodbyegoodbyegoodbye
2. Make sure the above don't actually 404 and instead redirect to `/categories/`
3. Make sure a relevant redirect is created in the redirection plugin
4. Make sure no erroneous redirects are created due to weird edge cases
5. Make sure there are no errors thrown if the redirection plugin is disabled