### PR TITLE
Show wpcf-shirttail field at end of post content if it exists

### DIFF
--- a/wp-content/themes/sfpublicpress/functions.php
+++ b/wp-content/themes/sfpublicpress/functions.php
@@ -142,7 +142,13 @@ function sfpp_after_post_content() {
 	global $post;
 
 	if( get_post_meta( $post->ID, 'wpcf-shirttail' ) ) {
-		echo get_post_meta( $post->ID, 'wpcf-shirttail', true );
+		printf(
+			'<div class="wpcf-shirttail">
+				<hr/>
+				%1$s
+			</div>',
+			get_post_meta( $post->ID, 'wpcf-shirttail', true )
+		);
 	}
 
 }


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Uses the `largo_after_post_content` action to show the `wpcf-shirttail` meta if it exists

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #144

## Testing/Questions

Features that this PR affects:

- Custom shirttail field

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. View a post that has a `wpcf-shirttail` custom meta field, such as http://sfpublicpress.flywheelsites.com/remaking-rent-control-if-voters-approve/ (post ID 3443) and make sure it displays at the end of the post content
2. View a post that doesn't have that custom meta field and make sure nothing funky is happening