### PR TITLE
Remove large thumbnails for homepage featured content

### DIFF
--- a/wp-content/themes/sfpublicpress/partials/content.php
+++ b/wp-content/themes/sfpublicpress/partials/content.php
@@ -13,7 +13,7 @@ $args = array (
 	'values' => get_post_custom( $post->ID ),
 
 	// this should be filtered in the event of a term-specific archive
-	'featured' => has_term( 'homepage-featured', 'prominence' ),
+	'featured' => false,
 
 	// $show_thumbnail does not control whether or not the thumbnail is displayed;
 	// it controls whether or not the thumbnail is displayed normally.


### PR DESCRIPTION
Resolves https://github.com/INN/umbrella-sfpublicpress/issues/165

## Changes

This pull request makes the following changes:

- Removes the large featured image presentation in archives for stories with the "Homepage Featured" term.

### Before
![Screen Shot 2020-09-09 at 15 15 44](https://user-images.githubusercontent.com/1754187/92643289-869f3200-f2af-11ea-8064-60ccc28f14fa.png)

### After

![Screen Shot 2020-09-09 at 15 15 58](https://user-images.githubusercontent.com/1754187/92643306-8c951300-f2af-11ea-900a-b22e1fbda951.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #165

## Testing/Questions

Features that this PR affects:

- archives, like year, author, and term

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] 

Steps to test this PR:

1. View an archive page